### PR TITLE
[streaming] StreamTask updated to handle chained states

### DIFF
--- a/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/OutputHandler.java
+++ b/flink-staging/flink-streaming/flink-streaming-core/src/main/java/org/apache/flink/streaming/runtime/tasks/OutputHandler.java
@@ -49,7 +49,7 @@ public class OutputHandler<OUT> {
 	private ClassLoader cl;
 	private Collector<OUT> outerCollector;
 
-	public List<ChainableStreamOperator<?, ?>> chainedOperators;
+	private List<ChainableStreamOperator<?, ?>> chainedOperators;
 
 	private Map<StreamEdge, StreamOutput<?>> outputMap;
 
@@ -97,6 +97,10 @@ public class OutputHandler<OUT> {
 
 	public Collection<StreamOutput<?>> getOutputs() {
 		return outputMap.values();
+	}
+	
+	public List<ChainableStreamOperator<?, ?>> getChainedOperators(){
+		return chainedOperators;
 	}
 
 	/**

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureStreamingRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureStreamingRecoveryITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.test.recovery;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -77,25 +78,15 @@ public class ProcessFailureStreamingRecoveryITCase extends AbstractProcessFailur
 		env.enableCheckpointing(200);
 
 		DataStream<Long> result = env.addSource(new SleepyDurableGenerateSequence(coordinateDir, DATA_COUNT))
-
-				// make sure every mapper is involved
-//				.shuffle()
-
-				// populate the coordinate directory so we can proceed to TaskManager failure
-				.map(new RichMapFunction<Long, Long>() {
-
-					private boolean markerCreated = false;
-
+				// add a non-chained no-op map to test the chain state restore logic
+				.distribute().map(new MapFunction<Long, Long>() {
 					@Override
 					public Long map(Long value) throws Exception {
-						if (!markerCreated) {
-							int taskIndex = getRuntimeContext().getIndexOfThisSubtask();
-							touchFile(new File(coordinateDir, READY_MARKER_FILE_PREFIX + taskIndex));
-							markerCreated = true;
-						}
 						return value;
 					}
-				});
+				})
+				// populate the coordinate directory so we can proceed to TaskManager failure
+				.map(new StatefulMapper(coordinateDir));				
 
 		//write result to temporary file
 		result.addSink(new RichSinkFunction<Long>() {
@@ -161,7 +152,6 @@ public class ProcessFailureStreamingRecoveryITCase extends AbstractProcessFailur
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void run(Collector<Long> collector) throws Exception {
 
 			StreamingRuntimeContext context = (StreamingRuntimeContext) getRuntimeContext();
@@ -201,6 +191,44 @@ public class ProcessFailureStreamingRecoveryITCase extends AbstractProcessFailur
 		@Override
 		public void restoreState(Long state) {
 			collected = state;
+		}
+	}
+	
+	public static class StatefulMapper extends RichMapFunction<Long, Long> implements
+			Checkpointed<Integer> {
+		private boolean markerCreated = false;
+		private File coordinateDir;
+		private boolean restored = false;
+
+		public StatefulMapper(File coordinateDir) {
+			this.coordinateDir = coordinateDir;
+		}
+
+		@Override
+		public Long map(Long value) throws Exception {
+			if (!markerCreated) {
+				int taskIndex = getRuntimeContext().getIndexOfThisSubtask();
+				touchFile(new File(coordinateDir, READY_MARKER_FILE_PREFIX + taskIndex));
+				markerCreated = true;
+			}
+			return value;
+		}
+
+		@Override
+		public void close() {
+			if (!restored) {
+				fail();
+			}
+		}
+
+		@Override
+		public Integer snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
+			return 1;
+		}
+
+		@Override
+		public void restoreState(Integer state) {
+			restored = true;
 		}
 	}
 


### PR DESCRIPTION
This commit enables state checkpoints for chained tasks as well by wrapping the the states of the chained tasks into a List.