### PR TITLE
[FLINK-5867] [flip-1] fix testMutilRegionFailoverAtSameTime in FailoverRegionTest and correct some annonations

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -954,9 +954,6 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 						}
 					});
 
-					for (ExecutionJobVertex ejv : verticesInCreationOrder) {
-						ejv.cancel();
-					}
 					return;
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
@@ -195,7 +195,7 @@ public class FailoverRegion {
 		catch (GlobalModVersionMismatch e) {
 			// happens when a global recovery happens concurrently to the regional recovery
 			// go back to a clean state
-			state = JobStatus.CREATED;
+			state = JobStatus.RUNNING;
 		}
 		catch (Throwable e) {
 			LOG.info("FailoverRegion {} reset fail, will failover again.", id);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartIndividualStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartIndividualStrategy.java
@@ -55,7 +55,7 @@ public class RestartIndividualStrategy extends FailoverStrategy {
 	private final Executor callbackExecutor;
 
 	/**
-	 * Creates a new failover strategy that recovers from failures by restarting all tasks
+	 * Creates a new failover strategy that recovers from failures by restarting only the failed task
 	 * of the execution graph.
 	 * 
 	 * <p>The strategy will use the ExecutionGraph's future executor for callbacks.
@@ -67,7 +67,7 @@ public class RestartIndividualStrategy extends FailoverStrategy {
 	}
 
 	/**
-	 * Creates a new failover strategy that recovers from failures by restarting all tasks
+	 * Creates a new failover strategy that recovers from failures by restarting only the failed task
 	 * of the execution graph.
 	 *
 	 * @param executionGraph The execution graph to handle.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartPipelinedRegionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartPipelinedRegionStrategy.java
@@ -46,7 +46,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class RestartPipelinedRegionStrategy extends FailoverStrategy {
 
-	private static final Logger LOG = LoggerFactory.getLogger(RestartIndividualStrategy.class);
+	private static final Logger LOG = LoggerFactory.getLogger(RestartPipelinedRegionStrategy.class);
 
 	/** The execution graph on which this FailoverStrategy works */
 	private final ExecutionGraph executionGraph;


### PR DESCRIPTION
This pr contains several commits. 
1. fix testMutilRegionFailoverAtSameTime in FailoverRegionTest and add some annonations.
2. correct the logger and some annonations in RestartIndividualStrategy and RestartPipelinedRegionStrategy.
3. remove the redundant cancel call on  ExecutionJobVertex in the cacel() method in execution graph