### PR TITLE
[FLINK-5866] [flip-1] set the clean state to RUNNING and enhance the the test case

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverRegion.java
@@ -195,7 +195,7 @@ public class FailoverRegion {
 		catch (GlobalModVersionMismatch e) {
 			// happens when a global recovery happens concurrently to the regional recovery
 			// go back to a clean state
-			state = JobStatus.CREATED;
+			state = JobStatus.RUNNING;
 		}
 		catch (Throwable e) {
 			LOG.info("FailoverRegion {} reset fail, will failover again.", id);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PipelinedRegionFailoverConcurrencyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PipelinedRegionFailoverConcurrencyTest.java
@@ -214,7 +214,7 @@ public class PipelinedRegionFailoverConcurrencyTest {
 		final ExecutionGraph graph = createSampleGraph(
 				jid,
 				new FailoverPipelinedRegionWithCustomExecutor(executor),
-				new FixedDelayRestartStrategy(2, 0), // one restart, no delay
+				new FixedDelayRestartStrategy(2, 0), // twice restart, no delay
 				slotProvider,
 				2);
 		RestartPipelinedRegionStrategy strategy = (RestartPipelinedRegionStrategy)graph.getFailoverStrategy();


### PR DESCRIPTION
This pr is for a small fix that when local recovery happend at the same time with global recovery, the FailoverRegion should reset to RUNNING state, as global recovery will start all the executions.
Add enhance the test case to ensure it.